### PR TITLE
This patch correct behavior during symlink creation process of lib* and /usr/lib*

### DIFF
--- a/usr/share/rear/build/GNU/Linux/090_create_lib_directories_and_symlinks.sh
+++ b/usr/share/rear/build/GNU/Linux/090_create_lib_directories_and_symlinks.sh
@@ -1,15 +1,17 @@
 # mirror library dir structure
 Log "Mirroring lib/ structure."
-for libdir in /lib* /usr/lib* ; do
+
+for libdir in /lib* /usr/lib*; do
     if [[ -L $libdir ]] ; then
+        libdir_basedir=$(dirname $libdir)
         target=$(readlink -f $libdir)
 
         if [[ ! -e $ROOTFS_DIR$target ]] ; then
             mkdir $v -p $ROOTFS_DIR$target >&2
         fi
-        ### move into ROOTFS_DIR to create 'absolute' symlinks
-        pushd $ROOTFS_DIR >/dev/null
-        ln $v -sf ${target#/} ${libdir#/} >&2
+
+        pushd ${ROOTFS_DIR}${libdir_basedir} >/dev/null
+        cp -d $libdir ./
         popd >/dev/null
     else
         mkdir $v -p $ROOTFS_DIR$libdir >&2


### PR DESCRIPTION
If symlink points to relative target on original system, it will be incorrectly
recreated in ReaR recovery system.
This applies to link directory in /usr (/lib /lib64 link are handled correctly)
c.f. Issue https://github.com/rear/rear/issues/1555